### PR TITLE
feat: Add method to check if CID is pinned to local node

### DIFF
--- a/ipfs_stac/client.py
+++ b/ipfs_stac/client.py
@@ -283,11 +283,26 @@ class Asset:
         self.local_gateway = local_gateway
         self.api_port = api_port
         self.data = None
-        if fetch_data:
+        is_pinned = self._is_pinned_to_local_node()
+        if fetch_data and not is_pinned:
             self.fetch()
 
     def __str__(self) -> str:
         return self.cid
+
+    def _is_pinned_to_local_node(self) -> bool:
+        """
+        Check if CID is pinned to local node
+        """
+        resp = requests.post(
+            f"http://{self.local_gateway}:{self.api_port}/api/v0/pin/ls?arg=/ipfs/{self.cid}",
+        )
+        if resp.status_code != 200:
+            raise Exception("Error checking if CID is pinned")
+        elif self.cid in resp.json()["Keys"]:
+            return True
+        else:
+            return False
 
     def fetch(self) -> None:
         try:


### PR DESCRIPTION
This commit adds a new method `_is_pinned_to_local_node()` to the `Asset` class in `client.py`. This method checks if the CID is pinned to the local IPFS node by making a request to the IPFS API. If the CID is pinned, it returns `True`; otherwise, it returns `False`. This method is used to determine whether to fetch the data for the asset or not.

Issue: Feature: Check if CID has been pinned before fetching #27